### PR TITLE
fix(antilag): add SetLastRuntime PR2 extension trap

### DIFF
--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -62,6 +62,7 @@ typedef intptr_t (*ext_syscall_t)(intptr_t *arg);
 static intptr_t EXT_SetSendNeeded(intptr_t *args);
 #endif
 static intptr_t EXT_MapExtFieldPtr(intptr_t *args);
+static intptr_t EXT_SetLastRuntime(intptr_t *args);
 #ifdef MVD_PEXT1_SPRAYS
 static intptr_t EXT_SprayClear(intptr_t *args);
 static intptr_t EXT_SprayClearAll(intptr_t *args);
@@ -77,6 +78,7 @@ struct
 	{"MapExtFieldPtr",	EXT_MapExtFieldPtr},
 	{"SetExtFieldPtr",	EXT_SetExtFieldPtr},
 	{"GetExtFieldPtr",	EXT_GetExtFieldPtr},
+	{"SetLastRuntime",	EXT_SetLastRuntime},
 #ifdef FTE_PEXT_CSQC
 	{"setsendneeded",		EXT_SetSendNeeded},
 #endif
@@ -2031,6 +2033,14 @@ intptr_t EXT_SetSendNeeded(intptr_t *args)
 	return 0;
 }
 #endif
+
+static intptr_t EXT_SetLastRuntime(intptr_t *args)
+{
+	int entnum = (int)args[1];
+	edict_t *ent = EDICT_NUM(entnum);
+	ent->e.lastruntime = sv.time;
+	return 0;
+}
 
 // To prevent mods from hardcoding field offsets which would cause engine incompatibilities.
 static uint32_t GetExtFieldCookie(void)


### PR DESCRIPTION
## Summary

Adds `SetLastRuntime(entnum)` as a PR2 extension syscall that sets `ent->e.lastruntime = sv.time`.

```c
static intptr_t EXT_SetLastRuntime(intptr_t *args)
{
    int entnum = (int)args[1];
    edict_t *ent = EDICT_NUM(entnum);
    ent->e.lastruntime = sv.time;
    return 0;
}
```

Registered as `{"SetLastRuntime", EXT_SetLastRuntime}` in `ext_syscalls[]`.

---

## Why this is needed

`SV_RunEntity` already contains this guard:

```c
if (ent->e.lastruntime == sv.time)
    return;
```

After `antilag_lagmove_all_proj` / `antilag_lagmove_all_proj_bounce` process a projectile (including its physics step with players rewound), the engine still calls `SV_RunNewmis` -> `SV_RunEntity` on the same entity during the same frame. This causes a **second, unintended physics step** that displaces the projectile beyond its intended antilag position.

By calling `SetLastRuntime` at every exit point of the antilag projectile functions, ktx marks the entity as already processed for this frame. `SV_RunEntity` then returns immediately -- the double step is eliminated.

---

## Pair PR

**dusty-qw/ktx#2** contains the stepping loop fix and the `trap_SetLastRuntime` calls. Both repos must be rebuilt together.

---

## Credit

Approach originally by **driztf**: [Iceman12k/mvdsv#1](https://github.com/Iceman12k/mvdsv/pull/1) / [Iceman12k/ktx#2](https://github.com/Iceman12k/ktx/pull/2).